### PR TITLE
Added Mars Helicopter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection listing all Achievements available on the GitHub profile.
 
 Following the launch of the first Mars Helicopter, [Ingenuity](https://en.wikipedia.org/wiki/Ingenuity_(helicopter)), GitHub [announced](https://github.blog/2021-04-19-open-source-goes-to-mars/) the new Achievements section:
 
-> We are also using this opportunity to introduce a new Achievements section to the GitHub profile. Right now, Achievements include the Mars 2020 Helicopter Mission badge, the [Arctic Code Vault](https://archiveprogram.github.com/arctic-vault/) badge, and a badge for sponsoring open source work via [GitHub Sponsors](https://github.com/sponsors).
+> We are also using this opportunity to introduce a new Achievements section to the GitHub profile. Right now, Achievements include the [Mars 2020 Helicopter Mission](https://github.com/readme/featured/nasa-ingenuity-helicopter) badge, the [Arctic Code Vault](https://archiveprogram.github.com/arctic-vault/) badge, and a badge for sponsoring open source work via [GitHub Sponsors](https://github.com/sponsors).
 
 This repository attempts to list them all.
 


### PR DESCRIPTION
I have added the link to the official GitHub Mars Helicopter page, as it already existed for the Arctic Code Vault.