### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Thanks for helping keep this achievement list accurate.
+
+## Before opening an issue or pull request
+
+- Check the README and existing issues first to avoid duplicates.
+- For achievement criteria changes, include evidence such as a GitHub
+  announcement, GitHub Docs page, live profile example, or linked discussion.
+- For badge image changes, include a short note about where the asset came from
+  and how it was checked.
+
+## Pull requests
+
+Good pull requests for this repository are usually small and focused:
+
+- one achievement criteria update,
+- one documentation correction,
+- one badge asset update, or
+- one repository maintenance change.
+
+Please avoid broad rewrites, generated translations, or speculative criteria
+changes without supporting evidence.


### PR DESCRIPTION
Adds concise contributing guidelines for evidence-backed achievement criteria updates, badge asset changes, and repository maintenance contributions.

Closes #488.